### PR TITLE
Update commands and command tasks.

### DIFF
--- a/bootloader/include/loom/command.h
+++ b/bootloader/include/loom/command.h
@@ -6,11 +6,11 @@
 
 struct loom_command_t;
 
-typedef void (*loom_fn_t) (struct loom_command_t *, loom_usize_t, char *[]);
+typedef int (*loom_task_t) (struct loom_command_t *, loom_usize_t, char *[]);
 
 typedef struct loom_command_t
 {
-  loom_fn_t fn;
+  loom_task_t task;
   const char *name;
   void *data;
   struct loom_command_t *prev, *next;

--- a/bootloader/include/loom/console.h
+++ b/bootloader/include/loom/console.h
@@ -47,6 +47,7 @@ typedef struct loom_console_t
   void (*write_all) (struct loom_console_t *, loom_write_buffer_t[]);
 
   void *data;
+  loom_console_color_t save;
   struct loom_console_t *next;
 } loom_console_t;
 
@@ -60,6 +61,7 @@ loom_usize_t loom_wbufs_char_len (loom_write_buffer_t wbufs[]);
 
 void EXPORT (loom_console_register) (loom_console_t *console);
 void EXPORT (loom_console_clear) (void);
+
 void loom_console_write (loom_usize_t len, const char *buf);
 void loom_console_write_str (const char *s);
 void loom_console_write_all (loom_write_buffer_t wbufs[]);
@@ -68,6 +70,48 @@ static inline void
 loom_console_set_fg (loom_console_color_t fg)
 {
   LOOM_LIST_ITERATE (loom_consoles, console) { console->set_fg (console, fg); }
+}
+
+static inline void
+loom_console_save_fg (void)
+{
+  LOOM_LIST_ITERATE (loom_consoles, console)
+  {
+    console->save = console->get_fg (console);
+  }
+}
+
+static inline void
+loom_console_restore_fg (void)
+{
+  LOOM_LIST_ITERATE (loom_consoles, console)
+  {
+    console->set_fg (console, console->save);
+  }
+}
+
+static inline void
+loom_console_set_bg (loom_console_color_t bg)
+{
+  LOOM_LIST_ITERATE (loom_consoles, console) { console->set_bg (console, bg); }
+}
+
+static inline void
+loom_console_save_bg (void)
+{
+  LOOM_LIST_ITERATE (loom_consoles, console)
+  {
+    console->save = console->get_bg (console);
+  }
+}
+
+static inline void
+loom_console_restore_bg (void)
+{
+  LOOM_LIST_ITERATE (loom_consoles, console)
+  {
+    console->set_bg (console, console->save);
+  }
 }
 
 #endif

--- a/bootloader/src/core/linux.c
+++ b/bootloader/src/core/linux.c
@@ -1,5 +1,5 @@
 #include "loom/command.h"
-#include "loom/print.h"
+#include "loom/error.h"
 
 // LOOM_MOD (linux)
 
@@ -50,12 +50,12 @@ typedef struct
   loom_uint32_t kernel_info_offset;
 } PACKED setup_header_t;
 
-static void
-command_linux (UNUSED loom_command_t *cmd, UNUSED loom_usize_t argc,
-               UNUSED char *argv[])
+static int
+linux_task (UNUSED loom_command_t *cmd, UNUSED loom_usize_t argc,
+            UNUSED char *argv[])
 {
-  loom_printf ("Not yet implemented.\n");
-  return;
+  loom_error (LOOM_ERR_BAD_ARG, "unimplemented");
+  return -1;
 
   /*loom_memcpy (&hdr, (void *) loom_modbase, sizeof (hdr));
 
@@ -111,7 +111,7 @@ command_linux (UNUSED loom_command_t *cmd, UNUSED loom_usize_t argc,
 
 static loom_command_t linux_command = {
   .name = "linux",
-  .fn = command_linux,
+  .task = linux_task,
 };
 
 /*LOOM_MOD_INIT () { loom_command_register (&linux_command); }

--- a/bootloader/src/core/shell.c
+++ b/bootloader/src/core/shell.c
@@ -97,7 +97,18 @@ shell_exec_command (shell_t *shell)
   command = loom_command_find (argv[0]);
 
   if (command)
-    command->fn (command, argc, argv);
+    {
+      if (command->task (command, argc, argv))
+        {
+          loom_printf ("%s: ", argv[0]);
+          loom_console_save_fg ();
+          loom_console_set_fg (LOOM_CONSOLE_COLOR_LIGHT_RED);
+          loom_printf ("error: ");
+          loom_console_restore_fg ();
+          loom_printf ("%s\n", loom_error_get ());
+          loom_error_clear ();
+        }
+    }
   else
     loom_printf ("unknown command: '%s'\n", argv[0]);
 

--- a/bootloader/src/mods/hello.c
+++ b/bootloader/src/mods/hello.c
@@ -4,16 +4,17 @@
 
 LOOM_MOD (hello)
 
-static void
-command_hello (UNUSED loom_command_t *cmd, UNUSED loom_usize_t argc,
-               UNUSED char *argv[])
+static int
+hello_task (UNUSED loom_command_t *cmd, UNUSED loom_usize_t argc,
+            UNUSED char *argv[])
 {
   loom_printf ("Hello!\n");
+  return 0;
 }
 
 static loom_command_t hello_command = {
   .name = "hello",
-  .fn = command_hello,
+  .task = hello_task,
 };
 
 LOOM_MOD_INIT () { loom_command_register (&hello_command); }


### PR DESCRIPTION
Update commands to match an interface that returns a status code. Also create more consistent error messages for commands that follows the format [command name]: error: [error message].

Closes #3.