### PR TITLE
Created a boundary tag allocator that meaningfully supports freeing.

### DIFF
--- a/bootloader/include/loom/mm.h
+++ b/bootloader/include/loom/mm.h
@@ -4,22 +4,17 @@
 #include "compiler.h"
 #include "types.h"
 
-typedef struct loom_reserved_memory_t
-{
-  struct loom_reserved_memory_t *next;
-} loom_reserved_memory_t;
-
 void loom_mm_add_region (loom_usize_t address, loom_usize_t length);
-
-loom_usize_t loom_mm_bytes_free (void);
-loom_usize_t loom_mm_bytes_allocated (void);
 
 void *EXPORT (loom_malloc) (loom_usize_t size);
 void *EXPORT (loom_zalloc) (loom_usize_t size);
 void *EXPORT (loom_calloc) (loom_usize_t n, loom_usize_t size);
-void *EXPORT (loom_realloc) (void *p, loom_usize_t oldsize,
-                             loom_usize_t newsize);
+void *EXPORT (loom_realloc) (void *p, loom_usize_t newsize);
 
 void EXPORT (loom_free) (void *p);
+
+int EXPORT (loom_mm_iterate) (int (*hook) (loom_address_t p, loom_usize_t n,
+                                           loom_bool_t isfree, void *data),
+                              void *data);
 
 #endif

--- a/bootloader/src/core/main.c
+++ b/bootloader/src/core/main.c
@@ -5,8 +5,6 @@
 #include "loom/shell.h"
 #include "loom/symbol.h"
 
-extern void loom_mod_init (void);
-
 void
 loom_main (void)
 {
@@ -15,7 +13,6 @@ loom_main (void)
   loom_register_export_symbols ();
   loom_init_core_cmds ();
   loom_core_modules_load ();
-  loom_mod_init ();
   loom_shell_exec ();
   for (;;)
     ;

--- a/bootloader/src/core/mm.c
+++ b/bootloader/src/core/mm.c
@@ -5,30 +5,64 @@
 #include "loom/math.h"
 #include "loom/mm.h"
 #include "loom/module.h"
+#include "loom/string.h"
 
-#define ALIGN         _Alignof (max_align_t)
-#define ALIGN_MINUS_1 (ALIGN - 1)
-#define MAGIC         0xA110CA7E
-#define MAGIC_OF(X)                                                           \
+#define CHUNK_SIZE         8U
+#define CHUNK_SIZE_MINUS_1 (CHUNK_SIZE - 1)
+
+#define MIN_ALLOC CHUNK_SIZE * 2
+
+#define ARENA_MAGIC_OF(X)                                                     \
   ({                                                                          \
     arena_t *a = (X);                                                         \
-    MAGIC ^ a->length ^ a->offset ^ (loom_uintptr_t) a->next;                 \
+    ARENA_MAGIC ^ a->length ^ (loom_address_t) a->freelist                    \
+        ^ (loom_address_t) a->next;                                           \
   })
 
-#define ALIGN_DOWN(X) ((X) & ~ALIGN_MINUS_1)
-#define ALIGN_UP(X)   ALIGN_DOWN ((X) + ALIGN_MINUS_1)
+#define CHUNK_ALIGN_DOWN(X) ((X) & ~CHUNK_SIZE_MINUS_1)
+#define CHUNK_ALIGN_UP(X)   CHUNK_ALIGN_DOWN ((X) + CHUNK_SIZE_MINUS_1)
 
 typedef struct arena_t
 {
   loom_usize_t length;
-  loom_usize_t offset;
-  loom_usize_t prev_alloc;
-  loom_uint32_t magic;
+  struct free_chunk *freelist;
   struct arena_t *next;
-} arena_t;
+#define ARENA_MAGIC 0xFA159B7E
+  loom_usize_t magic;
+} PACKED arena_t;
 
-compile_assert (ALIGN / _Alignof (arena_t) >= 1,
-                "arena_t alignment must match ALIGN.");
+typedef struct
+{
+#define CHUNK_FLAG_INUSE (1U << 0)
+#define CHUNK_FLAG_MASK  (~7UL)
+  loom_usize_t prev_size;
+  loom_usize_t size;
+} PACKED chunk_t;
+
+typedef struct free_chunk
+{
+  chunk_t base;
+  struct free_chunk *prev, *next;
+} PACKED free_chunk_t;
+
+compile_assert (CHUNK_SIZE >= _Alignof (arena_t),
+                "arena_t alignment must be less than or equal to CHUNK_SIZE.");
+
+compile_assert (MIN_ALLOC >= sizeof (arena_t),
+                "arena_t must fit within MIN_ALLOC.");
+
+compile_assert (CHUNK_SIZE >= _Alignof (chunk_t),
+                "chunk_t alignment must be less than or equal to CHUNK_SIZE.");
+
+compile_assert (MIN_ALLOC >= sizeof (chunk_t),
+                "chunk_t must fit within MIN_ALLOC.");
+
+compile_assert (
+    CHUNK_SIZE >= _Alignof (free_chunk_t),
+    "free_chunk_t alignment must be less than or equal to CHUNK_SIZE.");
+
+compile_assert (MIN_ALLOC >= sizeof (free_chunk_t),
+                "free_chunk_t must fit within MIN_ALLOC.");
 
 static arena_t *arenas = NULL;
 
@@ -36,22 +70,21 @@ void
 loom_mm_add_region (loom_usize_t address, loom_usize_t length)
 {
   loom_usize_t tmp;
-  loom_usize_t aligned_arena_size;
   loom_address_t modend;
   loom_bool_t exit = 0;
 
   if (address > LOOM_USIZE_MAX - length)
     length = LOOM_USIZE_MAX - address;
 
-  if (address > LOOM_USIZE_MAX - ALIGN_MINUS_1)
+  if (address > LOOM_USIZE_MAX - CHUNK_SIZE_MINUS_1)
     return;
 
-  tmp = ALIGN_UP (address);
+  tmp = CHUNK_ALIGN_UP (address);
 
   if (loom_sub (length, tmp - address, &length))
     return;
 
-  length = ALIGN_DOWN (length);
+  length = CHUNK_ALIGN_DOWN (length);
 
   address = tmp;
 
@@ -69,90 +102,166 @@ loom_mm_add_region (loom_usize_t address, loom_usize_t length)
       loom_mm_add_region (modend, (address + length) - modend);
     }
 
-  if (exit)
+  if (exit || length < CHUNK_SIZE * 4)
     return;
 
-  aligned_arena_size = ALIGN_UP (sizeof (arena_t));
+  free_chunk_t *fchunk = (free_chunk_t *) (address + MIN_ALLOC);
 
-  if (length < aligned_arena_size + ALIGN)
-    return;
+  *fchunk = (free_chunk_t) {
+    .base = { .prev_size = CHUNK_FLAG_INUSE, .size = length - MIN_ALLOC },
+    .prev = NULL,
+    .next = NULL,
+  };
 
   arena_t *arena = (arena_t *) address;
-  arena->length = length - aligned_arena_size;
-  arena->offset = aligned_arena_size;
-  arena->prev_alloc = 0;
+  arena->length = length;
+  arena->freelist = fchunk;
   arena->next = arenas;
-  arena->magic = MAGIC_OF (arena);
+  arena->magic = ARENA_MAGIC_OF (arena);
 
   arenas = arena;
 }
 
-loom_usize_t
-loom_mm_bytes_free (void)
+static void
+update_next (arena_t *arena, chunk_t *chunk, loom_bool_t differ)
 {
-  loom_usize_t bytes = 0;
+  chunk_t *nchunk;
+  loom_usize_t chunk_size = chunk->size & CHUNK_FLAG_MASK;
 
-  LOOM_LIST_ITERATE (arenas, arena)
-  {
-    if (arena->magic != MAGIC_OF (arena))
-      loom_panic ("heap corruption detected");
-    bytes += arena->length;
-  }
+  loom_address_t address = (loom_address_t) chunk,
+                 arena_end = (loom_address_t) arena + arena->length;
 
-  return bytes;
+  // If we either overflow the address space or the arena,
+  // something went wrong.
+  if (loom_add (address, chunk_size, &address) || address > arena_end)
+    loom_panic ("heap corruption detected");
+
+  // We are the last chunk. There is no next chunk to update.
+  if (address == arena_end)
+    return;
+
+  // Minimum MIN_ALLOC per free_chunk_t or allocation.
+  // If we have less than that, something went wrong.
+  if (arena_end - address < MIN_ALLOC)
+    loom_panic ("heap corruption detected");
+
+  // If our address is misaligned, something went wrong.
+  if (address & CHUNK_SIZE_MINUS_1)
+    loom_panic ("heap corruption detected");
+
+  nchunk = (chunk_t *) address;
+
+  int i1 = chunk->size & CHUNK_FLAG_INUSE,
+      i2 = nchunk->prev_size & CHUNK_FLAG_INUSE;
+
+  if ((differ && i1 == i2) || (!differ && i1 != i2))
+    loom_panic ("heap corruption detected");
+
+  nchunk->prev_size = chunk->size;
 }
 
-loom_usize_t
-loom_mm_bytes_allocated (void)
+static void
+unlink_free_chunk (arena_t *arena, free_chunk_t *fchunk)
 {
-  loom_usize_t bytes = 0;
+  if (fchunk->prev)
+    fchunk->prev->next = fchunk->next;
+  else
+    {
+      if (arena->freelist != fchunk)
+        loom_panic ("heap corruption detected");
 
-  LOOM_LIST_ITERATE (arenas, arena)
-  {
-    if (arena->magic != MAGIC_OF (arena))
-      loom_panic ("heap corruption detected");
-    bytes += arena->offset;
-  }
+      arena->freelist = fchunk->next;
+      arena->magic = ARENA_MAGIC_OF (arena);
+    }
 
-  return bytes;
+  if (fchunk->next)
+    fchunk->next->prev = fchunk->prev;
+
+  fchunk->prev = fchunk->next = NULL;
+}
+
+static void
+link_free_chunk (arena_t *arena, free_chunk_t *fchunk)
+{
+  fchunk->prev = NULL;
+  fchunk->next = arena->freelist;
+
+  if (arena->freelist)
+    {
+      if (arena->freelist->prev)
+        loom_panic ("heap corruption detected");
+
+      arena->freelist->prev = fchunk;
+    }
+
+  arena->freelist = fchunk;
+  arena->magic = ARENA_MAGIC_OF (arena);
 }
 
 void *
 loom_malloc (loom_usize_t size)
 {
-  arena_t *arena;
-
-  if (!size)
-    return NULL;
-
-  if (size > LOOM_USIZE_MAX - ALIGN_MINUS_1)
-    return NULL;
-
-  size = ALIGN_UP (size);
-  arena = arenas;
-
-  while (arena)
+  if (loom_add (size, CHUNK_SIZE_MINUS_1, &size)
+      || ((size &= ~CHUNK_SIZE_MINUS_1), loom_add (size, CHUNK_SIZE, &size)))
     {
-      void *p;
-
-      if (arena->magic != MAGIC_OF (arena))
-        loom_panic ("heap corruption detected");
-
-      if (arena->length < size)
-        goto next;
-
-      p = (char *) arena + arena->offset;
-
-      arena->length -= size;
-      arena->offset += size;
-      arena->prev_alloc = size;
-      arena->magic = MAGIC_OF (arena);
-
-      return p;
-
-    next:
-      arena = arena->next;
+      loom_error (LOOM_ERR_OVERFLOW, "requested malloc size too big");
+      return NULL;
     }
+
+  LOOM_LIST_ITERATE (arenas, arena)
+  {
+    free_chunk_t *fchunk;
+
+    if (ARENA_MAGIC_OF (arena) != arena->magic)
+      loom_panic ("heap corruption detected");
+
+    fchunk = arena->freelist;
+
+    while (fchunk)
+      {
+        loom_usize_t chunk_size;
+
+        if (fchunk->base.size & CHUNK_FLAG_INUSE)
+          loom_panic ("heap corruption detected");
+
+        chunk_size = fchunk->base.size & CHUNK_FLAG_MASK;
+
+        if (chunk_size >= size)
+          {
+            chunk_t *newchunk = (chunk_t *) fchunk;
+
+            unlink_free_chunk (arena, fchunk);
+
+            if (chunk_size - size >= MIN_ALLOC)
+              {
+                loom_usize_t split_size = chunk_size - size;
+                loom_address_t address = (loom_address_t) fchunk;
+                free_chunk_t *nfchunk = (free_chunk_t *) (address + size);
+
+                newchunk->size = size | CHUNK_FLAG_INUSE;
+
+                *nfchunk = (free_chunk_t) {
+                  .base = { .prev_size = (size | CHUNK_FLAG_INUSE),
+                            .size = split_size },
+                };
+
+                link_free_chunk (arena, nfchunk);
+
+                update_next (arena, &nfchunk->base, 1);
+              }
+            else
+              {
+                // Note: Don't lose bytes!
+                newchunk->size = chunk_size | CHUNK_FLAG_INUSE;
+                update_next (arena, newchunk, 1);
+              }
+
+            return (char *) newchunk + CHUNK_SIZE;
+          }
+
+        fchunk = fchunk->next;
+      }
+  }
 
   return NULL;
 }
@@ -185,72 +294,207 @@ loom_calloc (loom_usize_t n, loom_usize_t size)
 }
 
 void *
-loom_realloc (void *p, loom_usize_t oldsize, loom_usize_t newsize)
+loom_realloc (void *p, loom_usize_t n)
 {
-  loom_usize_t copy;
-  void *np;
-  char *c, *nc;
+  loom_usize_t copy, oldsize;
+  loom_address_t address = (loom_address_t) p;
 
-  if (!newsize)
+  chunk_t *chunk;
+  void *new = loom_malloc (n);
+
+  if (!new)
     return NULL;
+  else if (!p)
+    return new;
 
-  if (!p)
-    return loom_malloc (newsize);
+  if (address & CHUNK_SIZE_MINUS_1)
+    loom_panic ("realloc: invalid pointer %p", p);
 
-  c = p;
+  // This is undefined behavior if p
+  // is misaligned or is an invalid pointer.
+  chunk = (chunk_t *) ((char *) p - CHUNK_SIZE);
+  oldsize = chunk->size & CHUNK_FLAG_MASK;
+  copy = n > oldsize ? oldsize : n;
 
-  np = loom_malloc (newsize);
-  nc = np;
+  loom_memcpy (new, p, copy);
 
-  if (!np)
-    return NULL;
-
-  copy = newsize > oldsize ? oldsize : newsize;
-  for (loom_usize_t i = 0; i < copy; ++i)
-    nc[i] = c[i];
-
+  // Let free do all the error checking here.
+  // This is safe since we only have one thread of execution.
   loom_free (p);
 
-  return np;
+  return new;
 }
 
 void
 loom_free (void *p)
 {
-  loom_usize_t arena_aligned_size = ALIGN_UP (sizeof (arena_t));
+  loom_address_t address = (loom_address_t) p;
 
-  loom_uintptr_t addr = (loom_uintptr_t) p;
-
-  // Do nothing on NULL.
-  if (!addr)
-    return;
-
-  if (addr != ALIGN_DOWN (addr))
-    loom_panic ("invalid pointer");
+  if (loom_sub (address, CHUNK_SIZE, &address) || address & CHUNK_SIZE_MINUS_1
+      || address > LOOM_ADDRESS_MAX - MIN_ALLOC)
+    loom_panic ("free: invalid pointer %p", p);
 
   LOOM_LIST_ITERATE (arenas, arena)
   {
-    loom_uintptr_t arena_addr;
+    loom_address_t arena_start, arena_end, chunk_end;
+    chunk_t *chunk;
+    free_chunk_t *fchunk;
+    loom_bool_t inuse, differ = 1;
 
-    if (arena->magic != MAGIC_OF (arena))
+    if (ARENA_MAGIC_OF (arena) != arena->magic)
       loom_panic ("heap corruption detected");
 
-    arena_addr = (loom_uintptr_t) arena;
+    arena_start = (loom_address_t) arena + MIN_ALLOC;
+    arena_end = (loom_address_t) arena + arena->length;
 
-    if (addr >= arena_addr + arena_aligned_size
-        && addr < arena_addr + arena->offset)
+    if (address < arena_start || address + MIN_ALLOC > arena_end)
+      continue;
+
+    chunk = (chunk_t *) address;
+
+    // Chunk should be allocated. If not, we got
+    // a bad pointer or there is heap corruption.
+    if (!(chunk->size & CHUNK_FLAG_INUSE))
+      loom_panic ("heap corruption detected");
+
+    fchunk = (free_chunk_t *) chunk;
+    fchunk->base.size &= ~CHUNK_FLAG_INUSE;
+
+    // Speculatively link the free chunk.
+    // If we perform any backward coalescing, we unlink this.
+    link_free_chunk (arena, fchunk);
+
+    inuse = fchunk->base.prev_size & CHUNK_FLAG_INUSE;
+
+    // Perform backward coalescing.
+    while (!inuse)
       {
-        if (addr + arena->prev_alloc == arena_addr + arena->offset)
+        free_chunk_t *bchunk;
+        loom_usize_t prev_size = fchunk->base.prev_size & CHUNK_FLAG_MASK,
+                     size;
+
+        if (prev_size < MIN_ALLOC || loom_sub (address, prev_size, &address)
+            || address < arena_start)
+          loom_panic ("heap corruption detected");
+
+        bchunk = (free_chunk_t *) address;
+        if (bchunk->base.size & CHUNK_FLAG_INUSE
+            || (bchunk->base.size & CHUNK_FLAG_MASK) != prev_size)
+          loom_panic ("heap corruption detected");
+
+        size = fchunk->base.size & CHUNK_FLAG_MASK;
+
+        unlink_free_chunk (arena, fchunk);
+
+        // Grow back chunk.
+        loom_usize_t flags = bchunk->base.size & ~CHUNK_FLAG_MASK;
+        bchunk->base.size = (prev_size + size) | flags;
+
+        fchunk = bchunk;
+        inuse = bchunk->base.prev_size & CHUNK_FLAG_INUSE;
+      }
+
+    chunk_end
+        = (loom_address_t) fchunk + (fchunk->base.size & CHUNK_FLAG_MASK);
+
+    inuse = 0;
+
+    // Coalesce forward.
+    while (chunk_end < arena_end)
+      {
+        free_chunk_t *nchunk;
+        loom_usize_t size = fchunk->base.size & CHUNK_FLAG_MASK;
+
+        chunk = (chunk_t *) chunk_end;
+        if (chunk->size & CHUNK_FLAG_INUSE)
           {
-            arena->offset -= arena->prev_alloc;
-            arena->length += arena->prev_alloc;
-            arena->prev_alloc = 0;
-            arena->magic = MAGIC_OF (arena);
+            inuse = 1;
+            break;
           }
 
-        return;
+        differ = 0;
+
+        nchunk = (free_chunk_t *) chunk;
+
+        unlink_free_chunk (arena, nchunk);
+
+        loom_usize_t flags = fchunk->base.size & ~CHUNK_FLAG_MASK,
+                     newsize = nchunk->base.size & CHUNK_FLAG_MASK;
+
+        if (newsize < MIN_ALLOC || loom_add (size, newsize, &size)
+            || loom_add (chunk_end, newsize, &chunk_end))
+          loom_panic ("heap corruption detected");
+
+        fchunk->base.size = size | flags;
       }
+
+    if (chunk_end != arena_end && !inuse)
+      // Either heap corruption or some logic error.
+      loom_panic ("heap corruption detected");
+
+    update_next (arena, &fchunk->base, differ);
+
+    // All done.
+    return;
   }
 
-  loom_panic ("invalid pointer");
+  loom_panic ("free: invalid pointer %p", p);
+}
+
+int
+loom_mm_iterate (int (*hook) (loom_address_t p, loom_usize_t n,
+                              loom_bool_t isfree, void *data),
+                 void *data)
+{
+  if (!hook)
+    {
+      loom_error (LOOM_ERR_BAD_ARG, "invalid memory manager iterate hook %p",
+                  hook);
+      return -1;
+    }
+
+  // Note: This serves as a way of validating the heap as well as
+  // hooking and iterating free chunks and allocations.
+  LOOM_LIST_ITERATE (arenas, arena)
+  {
+    loom_address_t address = (loom_address_t) arena, arena_end;
+    loom_usize_t prev_size;
+    loom_bool_t first = 1;
+    chunk_t *chunk;
+
+    if (ARENA_MAGIC_OF (arena) != arena->magic
+        || loom_add (address, arena->length, &arena_end))
+      loom_panic ("heap corruption detected");
+
+    address += MIN_ALLOC;
+
+    while (address < arena_end)
+      {
+        int retval;
+
+        loom_usize_t chunk_size;
+        chunk = (chunk_t *) address;
+
+        chunk_size = chunk->size & CHUNK_FLAG_MASK;
+
+        if (chunk_size < MIN_ALLOC || (chunk_size & CHUNK_SIZE_MINUS_1)
+            || loom_add (address, chunk_size, &address) || address > arena_end
+            || (!first && prev_size != chunk->prev_size))
+          loom_panic ("heap corruption detected");
+
+        retval = hook (address - chunk_size, chunk_size,
+                       !(chunk->size & CHUNK_FLAG_INUSE), data);
+
+        if (retval)
+          return retval;
+
+        first = 0;
+        prev_size = chunk->size;
+      }
+
+    if (address != arena_end)
+      loom_panic ("heap corruption detected");
+  }
+
+  return 0;
 }

--- a/bootloader/src/core/shell.c
+++ b/bootloader/src/core/shell.c
@@ -70,15 +70,13 @@ shell_exec_command (shell_t *shell)
       if (argc == argvc)
         {
           char **newargv;
-          loom_usize_t oldargvc = argvc;
 
           if (!argvc)
             argvc = 1;
           else
             argvc *= 2;
 
-          newargv = loom_realloc (argv, oldargvc * sizeof (char *),
-                                  argvc * sizeof (char *));
+          newargv = loom_realloc (argv, argvc * sizeof (char *));
           if (!newargv)
             {
               loom_free (argv);

--- a/bootloader/src/core/string.c
+++ b/bootloader/src/core/string.c
@@ -9,7 +9,7 @@ loom_memcpy (void *restrict dst, const void *restrict src, loom_usize_t count)
   const char *s = src;
 
   if (!d || !s)
-    loom_panic ("loom_memcpy");
+    loom_panic ("memcpy");
 
   for (loom_usize_t i = 0; i < count; ++i)
     *d++ = *s++;
@@ -22,7 +22,7 @@ loom_memmove (void *dst, const void *src, loom_usize_t count)
   const char *s = src;
 
   if (!d || !s)
-    loom_panic ("loom_memmove");
+    loom_panic ("memmove");
 
   if ((loom_address_t) s < (loom_address_t) d)
     while (count--)
@@ -35,6 +35,9 @@ loom_memmove (void *dst, const void *src, loom_usize_t count)
 loom_usize_t
 loom_strlen (const char *s)
 {
+  if (!s)
+    loom_panic ("strlen");
+
   loom_usize_t len = 0;
   for (; s[len]; ++len)
     ;
@@ -45,6 +48,10 @@ int
 loom_strcmp (const char *s1, const char *s2)
 {
   unsigned char c1, c2;
+
+  if (!s1 || !s2)
+    loom_panic ("strcmp");
+
 read:
   c1 = (unsigned char) (*s1++);
   c2 = (unsigned char) (*s2++);
@@ -61,6 +68,9 @@ read:
 void
 loom_strlower (char *s)
 {
+  if (!s)
+    loom_panic ("strlower");
+
   while (s[0])
     {
       if (s[0] >= 'A' && s[0] <= 'Z')
@@ -91,7 +101,7 @@ loom_strtoi (char *s, int *out)
   char ch;
 
   if (!s[0])
-    return LOOM_ERR_BAD_ARG;
+    loom_panic ("strtoi");
 
   while ((ch = s[0]))
     {
@@ -161,6 +171,9 @@ loom_memcmp (const void *lhs, const void *rhs, loom_usize_t count)
   const unsigned char *l = lhs;
   const unsigned char *r = rhs;
 
+  if (!lhs || !rhs)
+    loom_panic ("memcmp");
+
   while (count--)
     {
       if (*l != *r)
@@ -177,6 +190,10 @@ loom_strdup (const char *s)
 {
   loom_usize_t len = loom_strlen (s);
   char *dups;
+
+  if (!s)
+    loom_panic ("strdup");
+
   if (len == LOOM_USIZE_MAX || !(dups = loom_malloc (len + 1)))
     return NULL;
   loom_memcpy (dups, s, len);


### PR DESCRIPTION
This implementation of malloc uses a boundary tag design with a header with prev_size and size before each allocation. Flags (for INUSE) in those respective chunks are used in the bottom three bits (which are unused due to alignment). The INUSE flag is utilized to allow for forward and backward coalescing of free chunks. 

Some improvements could be made to the realloc implementation as it doesn't permit growing in-place and instead opts for always allocating the new size and then freeing the old pointer. 

Closes #7.